### PR TITLE
setting value : 1 skips result between sets

### DIFF
--- a/minquery.go
+++ b/minquery.go
@@ -161,7 +161,7 @@ func (mq *minQuery) All(result interface{}, cursorFields ...string) (cursor stri
 	if mq.min != nil {
 		// min is inclusive, skip the first (which is the previous last)
 		cmd = append(cmd,
-			bson.DocElem{Name: "skip", Value: 1},
+			bson.DocElem{Name: "skip", Value: 0},
 			bson.DocElem{Name: "min", Value: mq.min},
 		)
 	}


### PR DESCRIPTION
If I have documents 1, 2, 3, 4, 5 and I set a NewCursor global variable. Each time minquery.All is called with say, a limit of 2, the way the NewCursors is being set, it displays 1, 2 then skips to 4 and 5. Document 3 is missing. Setting the Skip Value back to 0 corrects this.