### PR TITLE
Supports max query in descending order, and supports returning paged query information - if there are more results

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 Aside from original features suported in icza/minquery, this forked version (master) supports returning another value named 'hasMore' for callers to determine whether there still exists further results. With 'hasMore' as false there would be no need to request the next page any more.
 
 ## Below are the original README content from icza/minquery
+Except the following caller example code, due to interface change:
+
+    newCursor, err, hasMore := q.All(&users, "country", "name", "_id")
 
 [![GoDoc](https://godoc.org/github.com/icza/minquery?status.svg)](https://godoc.org/github.com/icza/minquery) [![Build Status](https://travis-ci.org/icza/minquery.svg?branch=master)](https://travis-ci.org/icza/minquery) [![Go Report Card](https://goreportcard.com/badge/github.com/icza/minquery)](https://goreportcard.com/report/github.com/icza/minquery)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # minquery
 
+## Note by zhangyi (windless0530)
+
+Aside from original features suported in icza/minquery, this forked version (master) supports returning another value named 'hasMore' for callers to determine whether there still exists further results. With 'hasMore' as false there would be no need to request the next page any more.
+
+## Below are the original README content from icza/minquery
+
 [![GoDoc](https://godoc.org/github.com/icza/minquery?status.svg)](https://godoc.org/github.com/icza/minquery) [![Build Status](https://travis-ci.org/icza/minquery.svg?branch=master)](https://travis-ci.org/icza/minquery) [![Go Report Card](https://goreportcard.com/badge/github.com/icza/minquery)](https://goreportcard.com/report/github.com/icza/minquery)
 
 MongoDB / `mgo.v2` query that supports _efficient_ pagination (cursors to continue listing documents where we left off).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The above solution using `minquery` looks like this:
     }
 
     var users []*User
-    newCursor, err := q.All(&users, "country", "name", "_id")
+    newCursor, err, hasMore := q.All(&users, "country", "name", "_id")
 
 And that's all. `newCursor` is the cursor to be used to fetch the next batch.
 

--- a/minquery.go
+++ b/minquery.go
@@ -263,7 +263,11 @@ func (mq *minQuery) All(result interface{}, cursorFields ...string) (cursor stri
 				return
 			}
 			cursorData := make(bson.D, len(cursorFields))
-			for i, cf := range cursorFields {
+			for i, cfd := range cursorFields {
+				cf := cfd
+				if '-' == cf[0] || '+' == cf[0] {
+					cf = cf[1:]
+				}
 				cursorData[i] = bson.DocElem{Name: cf, Value: doc[cf]}
 			}
 			cursor, err = mq.cursorCodec.CreateCursor(cursorData)


### PR DESCRIPTION
1. Fixed a bug that no result is given when Limit() hasn't been called (though it may seem strange to use min query without limit).
2. Add another return value 'hasMore' for callers to determine if there are more results in db, in paged query situations.
3. Supports max query when sorting descending, for example, querying latest events or messages in descending order.