### PR TITLE
fix bug: when there is descending sorting, min query the second page does not work

### DIFF
--- a/minquery.go
+++ b/minquery.go
@@ -202,7 +202,11 @@ func (mq *minQuery) All(result interface{}, cursorFields ...string) (cursor stri
 				return
 			}
 			cursorData := make(bson.D, len(cursorFields))
-			for i, cf := range cursorFields {
+			for i, cfd := range cursorFields {
+				cf := cfd
+				if '-' == cf[0] || '+' == cf[0] {
+					cf = cf[1:]
+				}
 				cursorData[i] = bson.DocElem{Name: cf, Value: doc[cf]}
 			}
 			cursor, err = mq.cursorCodec.CreateCursor(cursorData)


### PR DESCRIPTION
My case:

`db.msgs.createIndex({"read_flag": 1, "timestamp": -1, "_id": 1})`
`q := minquery.New(p.db, p.colNameMsgs, ff).Sort("read_flag", "-timestamp", "_id").Limit(int(req.MaxNum))`
`newCursor, err := q.All(&dbMsgs, "read_flag", "-timestamp", "_id")`

However, now result returned for the second page, where the first page is correct. Without "-timestamp" as condition and index, everything was right.

After debugging the code, I found that in the 'All' function, the returned data stored in 'doc' variable does not contain any field named '-timestamp' but 'timestamp', so I guess it may be a fix to remove the first letter.

Please check if this is reasonable. Thanks again.