### PR TITLE
Added hint to support mongo 4.2.X 

### DIFF
--- a/minquery.go
+++ b/minquery.go
@@ -4,7 +4,6 @@ package minquery
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
@@ -148,7 +147,6 @@ func (mq *minQuery) CursorCodec(cc CursorCodec) MinQuery {
 // All implements MinQuery.All().
 func (mq *minQuery) All(result interface{}, cursorFields ...string) (cursor string, err error) {
 	if mq.cursorErr != nil {
-		fmt.Println("Error in cusror ", err.Error())
 		return "", mq.cursorErr
 	}
 
@@ -226,4 +224,3 @@ func (mq *minQuery) All(result interface{}, cursorFields ...string) (cursor stri
 
 	return
 }
-


### PR DESCRIPTION
Starting in MongoDB 4.2, you must explicitly specify the particular index with the hint() method to run min() with the following exception: you do not need to hint if the find() query is an equality condition on the _id field { _id: <value> }.

In previous versions, you could run min() with or without explicitly hinting the index. If run without the hint in 4.0 and earlier, MongoDB selects the index using the fields in the indexBounds; however, if multiple indexes exist on same fields with different sort orders, the selection of the index may be ambiguous.
